### PR TITLE
Rewrite the build script.

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,7 +1,10 @@
+#!/usr/bin/env python3
 import argparse
 import os
 import subprocess
 import sys
+import shlex
+import distutils.spawn
 
 
 def parse_args():
@@ -11,30 +14,43 @@ def parse_args():
     parser.add_argument('-o', default='_build', dest='build_dir',
                         help='specify build directory (default: "_build")')
     args = parser.parse_args()
+
     return args
 
 
 def check_call(args, **kwargs):
     try:
-        subprocess.check_call(args, **kwargs)
+        subprocess.check_call(shlex.split(args), **kwargs)
     except subprocess.CalledProcessError as error:
         sys.exit(error.returncode)
+
+
+def check_environment():
+    check_exec_names = ['cmake', 'conan']
+
+    for name in check_exec_names:
+        exe = distutils.spawn.find_executable(name)
+        if not exe:
+            print("Please install \"{name}\" first.".format(name=name))
+            sys.exit(1)
 
 
 def main():
     args = parse_args()
 
-    check_call(['git', 'submodule', 'init'])
-    check_call(['git', 'submodule', 'update', '--recursive'])
+    check_environment()
+
+    check_call('git submodule init')
+    check_call('git submodule update --recursive')
 
     source_dir = os.path.realpath(args.source_dir)
     build_dir = os.path.realpath(args.build_dir)
 
-    check_call(['mkdir', '-p', build_dir])
+    check_call('mkdir -p {name}'.format(name=build_dir) )
     os.chdir(build_dir)
 
-    check_call(['conan', 'install', '--build=outdated', source_dir])
-    check_call(['conan', 'build', source_dir])
+    check_call('conan install --build=outdated {src_dir}'.format(src_dir=source_dir))
+    check_call('conan build {src_dir}'.format(src_dir=source_dir))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The change is as the following.

1. Refine coding style. There are two empty lines between functions.
2. Use `shlex.split()` to split user command. The function can let user to
   write command the same as in shell.
3. Add a check environment function. The project needs `cmake` and `conan`
   to build project. It's possible that users do not have the two
   program. Check them first and notify users to install them.